### PR TITLE
Fix textbox style for rtl texts

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "ir.quera.mattermost-rtl",
     "name": "Mattermost RTL",
     "description": "This plugin adds RTL support to Mattermost.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "min_server_version": "5.12.0",
     "webapp": {
         "bundle_path": "webapp/dist/main.js"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-rtl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This plugin adds RTL support to Mattermost.",
   "main": "src/index.js",
   "scripts": {

--- a/webapp/src/style.css
+++ b/webapp/src/style.css
@@ -48,3 +48,10 @@ code {
 .channel-header__description .header-description__text p {
     unicode-bidi: plaintext;
 }
+
+/* Fix textbox style for rtl texts that are hidden by send button */
+#post_textbox:not(:empty) {
+  margin-bottom: 3.5rem;
+  max-width: 100%;
+}
+


### PR DESCRIPTION
Fix textbox style for rtl texts that are not visible behind the send button.

Before:
![image](https://github.com/QueraTeam/mattermost-rtl/assets/33475817/8311f7aa-dd26-468d-aada-1ce6b3384947)

After:
![image (1)](https://github.com/QueraTeam/mattermost-rtl/assets/33475817/03c5b99e-8c40-4be6-a52c-0a9f56c200bd)
